### PR TITLE
Allow the `send` function to accept a single file as well as a list/array.

### DIFF
--- a/mailSender.py
+++ b/mailSender.py
@@ -119,6 +119,10 @@ class Mail:
             mail.attach(html_content)
 
             if attachments is not None:
+                if type(attachments) is not list:
+                    # `attachments` in just a single file (not a list)
+                    attachments = [attachments]  # Create a list of a single file
+
                 # Attaching an attachment
                 for attachment in attachments:
                     file_path = attachment


### PR DESCRIPTION
Fix for [#1](https://github.com/bzgec/python_helperLib/issues/1).

Allows the `send` function to accept a single file as well as a list/array.